### PR TITLE
Custom SSL certs and proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Installs and configures Ceph, a distributed network storage and filesystem desig
 
 The current version is focused on installing and configuring Ceph for Ubuntu, CentOS and RHEL.
 
-For documentation on how to use this cookbook, refer to the [USAGE](#USAGE) section.
+For documentation on how to use this cookbook, refer to the [USAGE](#usage) section.
 
 Note: The documentation is a WIP along with a few other features. This repo is actively managed.  
 

--- a/bootstrap/vms/environment_config.yaml
+++ b/bootstrap/vms/environment_config.yaml
@@ -16,3 +16,5 @@ vagrant:
     drive_size: 20480
     http_proxy:
     https_proxy:
+    ssl_ca_file_path:
+    ssl_intermediate_file_path:

--- a/bootstrap/vms/vagrant/Vagrantfile
+++ b/bootstrap/vms/vagrant/Vagrantfile
@@ -47,6 +47,10 @@ $storage_controller = environment['vagrant']['storage_controller']
 $domain = environment['vagrant']['domain']
 $http_proxy_server = environment['vagrant']['http_proxy']
 $https_proxy_server = environment['vagrant']['https_proxy']
+$ssl_ca_file_path = environment['vagrant']['ssl_ca_file_path']
+$ssl_intermediate_file_path = environment['vagrant']['ssl_intermediate_file_path']
+$ssl_ca_file = File.basename($ssl_ca_file_path)
+$ssl_intermediate_file = File.basename($ssl_intermediate_file_path)
 
 # Some settings for each VM
 $num_of_osds = environment['vagrant']['osd_drives']
@@ -63,19 +67,48 @@ $proxy_configuration_script = <<-EOH
   touch $HOME/proxy_config.sh
 EOH
 
+$proxy_string = ""
+
 unless $http_proxy_server.nil? or $http_proxy_server.empty?
     if $lsb_name == 'centos' or $lsb_name == 'rhel'
+        $bootstrap_node_name = servers.select { |k| k["types"] == ["bootstrap"] }[0]["name"]
         $proxy_configuration_script << <<-EOH
-            echo 'proxy="http://#{$http_proxy_server}";' | sudo tee -a /etc/yum.conf
+            echo 'Defaults    env_keep += "http_proxy https_proxy no_proxy SSL_CERT_FILE"' | sudo tee -a /etc/sudoers
+            echo 'export http_proxy=http://#{$http_proxy_server}' | sudo tee -a /etc/profile
+            echo 'export https_proxy=https://#{$https_proxy_server}' | sudo tee -a /etc/profile
+            echo 'export no_proxy=127.0.0.1,#{$bootstrap_node_name}.#{$domain}' | sudo tee -a /etc/profile
+            echo 'proxy=http://#{$http_proxy_server};' | sudo tee -a /etc/yum.conf
             echo 'export http_proxy=#{$http_proxy_server}' | tee -a $HOME/proxy_config.sh
         EOH
     end
+    $proxy_string = "export CEPH_CHEF_HTTP_PROXY=http://#{$http_proxy_server}\nexport CEPH_CHEF_HTTPS_PROXY=https://#{$https_proxy_server}\n"
+end
+
+# custom SSL CA cert support
+unless $ssl_ca_file.nil? or $ssl_ca_file.empty?
+  if $lsb_name == 'centos' or $lsb_name == 'rhel'
+    $proxy_configuration_script << <<-EOH
+        echo "export SSL_CERT_FILE='/etc/pki/ca-trust/source/anchors/chef-bcs_ca_bundle.crt'" | sudo tee -a /etc/profile
+        sudo cp /tmp/#{$ssl_ca_file} /etc/pki/ca-trust/source/anchors/
+        cat /tmp/#{$ssl_ca_file} | sudo tee /etc/pki/ca-trust/source/anchors/chef-bcs_ca_bundle.crt
+    EOH
+
+    unless $ssl_intermediate_file.nil? or $ssl_intermediate_file.empty?
+      $proxy_configuration_script << <<-EOH
+          sudo cp /tmp/#{$ssl_intermediate_file} /etc/pki/ca-trust/source/anchors/
+          cat /tmp/#{$ssl_intermediate_file} | sudo tee -a /etc/pki/ca-trust/source/anchors/chef-bcs_ca_bundle.crt
+      EOH
+    end
+
+    $proxy_configuration_script << <<-EOH
+        sudo update-ca-trust
+    EOH
+  end
 end
 
 unless $https_proxy_server.nil? or $https_proxy_server.empty?
     if $lsb_name == 'centos' or $lsb_name == 'rhel'
         $proxy_configuration_script << <<-EOH
-            echo 'proxy="https://#{$https_proxy_server}";' | sudo tee -a /etc/yum.conf
             echo 'export https_proxy=#{$https_proxy_server}' | tee -a $HOME/proxy_config.sh
         EOH
     end
@@ -138,6 +171,20 @@ Vagrant.configure("2") do |config|
         puts "<コ:彡 " + machine.vm.hostname + " <コ:彡"
         puts "-" * (machine.vm.hostname.length + 14)
 
+        # copy custom certs to host
+        unless $ssl_ca_file.nil? or $ssl_ca_file.empty?
+          machine.vm.provision "file", source: "#{$path}/../../#{$ssl_ca_file_path}", destination: "/tmp/#{$ssl_ca_file}"
+          unless $ssl_intermediate_file.nil? or $ssl_intermediate_file.empty?
+            machine.vm.provision "file", source: "#{$path}/../../#{$ssl_intermediate_file_path}", destination: "/tmp/#{$ssl_intermediate_file}"
+          end
+        end
+
+        # configure proxy servers (do not run as root)
+        machine.vm.provision "configure-proxy-servers", type: "shell" do |s|
+          s.privileged = false
+          s.inline = $proxy_configuration_script
+        end
+
         # Set up repositories
         # This is done here because we skip it in chef configuration PLUS there is an issue
         # where the package manager *may* update the kernel and when it does that the VBoxGuestAdditions
@@ -177,12 +224,6 @@ Vagrant.configure("2") do |config|
         machine.vm.provision "vbox-chg-permissions", type: "shell" do |s|
           s.privileged = true
           s.inline = "chmod +x vbox_check_guestaddons.sh"
-        end
-
-        # configure proxy servers (do not run as root)
-        machine.vm.provision "configure-proxy-servers", type: "shell" do |s|
-          s.privileged = false
-          s.inline = $proxy_configuration_script
         end
 
         machine.vm.provision "add-custom-key", type: "shell" do |s|
@@ -236,6 +277,7 @@ Vagrant.configure("2") do |config|
             File.open("#{$path}/ceph_chef_hosts.env", "w") { |file| file.write($hosts_string) }
             File.open("#{$path}/ceph_chef_adapters.env", "w") { |file| file.write($adapters_string) }
             File.open("#{$path}/ceph_chef_bootstrap.env", "w") { |file| file.write($bootstrap_name) }
+            File.open("#{$path}/ceph_chef_proxy.env", "w") { |file| file.write($proxy_string) }
         end
 
       end # config.vm.define

--- a/bootstrap/vms/vagrant/vagrant_base.sh
+++ b/bootstrap/vms/vagrant/vagrant_base.sh
@@ -29,6 +29,7 @@ source ../base_environment.sh
 source $REPO_ROOT/bootstrap/vms/ceph_chef_bootstrap.env
 source $REPO_ROOT/bootstrap/vms/ceph_chef_hosts.env
 source $REPO_ROOT/bootstrap/vms/ceph_chef_adapters.env
+source $REPO_ROOT/bootstrap/vms/ceph_chef_proxy.env
 
 source $REPO_ROOT/bootstrap/vms/vbox_functions.sh
 

--- a/bootstrap/vms/vagrant/vagrant_bootstrap_chef.sh
+++ b/bootstrap/vms/vagrant/vagrant_bootstrap_chef.sh
@@ -38,9 +38,14 @@ do_on_node $CEPH_CHEF_BOOTSTRAP "sudo chmod 0644 /etc/opscode/admin.pem /etc/ops
 do_on_node $CEPH_CHEF_BOOTSTRAP "mkdir -p \$HOME/.chef && echo -e \"chef_server_url 'https://$CEPH_CHEF_BOOTSTRAP.$BOOTSTRAP_DOMAIN/organizations/ceph'\\\nvalidation_client_name 'ceph-validator'\\\nvalidation_key '/etc/opscode/ceph-validator.pem'\\\nnode_name 'admin'\\\nclient_key '/etc/opscode/admin.pem'\\\nknife['editor'] = 'vim'\\\ncookbook_path [ \\\"#{ENV['HOME']}/chef-bcs/cookbooks\\\" ]\" > \$HOME/.chef/knife.rb"
 do_on_node $CEPH_CHEF_BOOTSTRAP "$KNIFE ssl fetch"
 
+if [ -n "$CEPH_CHEF_HTTP_PROXY" ];
+then
+  KNIFE_HTTP_PROXY_PARAM="--bootstrap-proxy \$http_proxy"
+fi
+
 # NOTE: If this command seems to stall then the network needs to be reset. Run ./vagrant_reset_network.sh from the
 # directory this script is located in. This will clean any network issues. Same holds true for other VMs.
-do_on_node $CEPH_CHEF_BOOTSTRAP "$KNIFE bootstrap -x vagrant -P vagrant --sudo $CEPH_CHEF_BOOTSTRAP_IP"
+do_on_node $CEPH_CHEF_BOOTSTRAP "$KNIFE bootstrap -x vagrant --bootstrap-no-proxy '$CEPH_CHEF_BOOTSTRAP.$BOOTSTRAP_DOMAIN' $KNIFE_HTTP_PROXY_PARAM -P vagrant --sudo $CEPH_CHEF_BOOTSTRAP_IP"
 
 # install the knife-acl plugin into embedded knife
 do_on_node $CEPH_CHEF_BOOTSTRAP "sudo /opt/opscode/embedded/bin/gem install /ceph-files/knife-acl-0.0.12.gem"

--- a/bootstrap/vms/vagrant/vagrant_bootstrap_chef_vms.sh
+++ b/bootstrap/vms/vagrant/vagrant_bootstrap_chef_vms.sh
@@ -24,13 +24,18 @@ source vagrant_base.sh
 
 # This ONLY bootstraps Chef on the working vms and sets up authorization via actor maps.
 
+if [ -n "$CEPH_CHEF_HTTP_PROXY" ];
+then
+  KNIFE_HTTP_PROXY_PARAM="--bootstrap-proxy \$http_proxy"
+fi
+
 for vm in ${ceph_vms[@]}; do
   # TODO: Make OS check here to do for Ubuntu or RHEL based...
   do_on_node $vm "sudo rpm -Uvh \$(find /ceph-files/ -name chef-\*rpm -not -name \*downloaded | tail -1)"
 
   # NOTE: If this command seems to stall then the network needs to be reset. Run ./vagrant_reset_network.sh from the
   # directory this script is located in. This will clean any network issues. Same holds true for other VMs.
-  do_on_node $CEPH_CHEF_BOOTSTRAP "$KNIFE bootstrap -x vagrant -P vagrant --sudo $vm.$BOOTSTRAP_DOMAIN"
+  do_on_node $CEPH_CHEF_BOOTSTRAP "$KNIFE bootstrap -x vagrant --bootstrap-no-proxy '$CEPH_CHEF_BOOTSTRAP.$BOOTSTRAP_DOMAIN,$vm.$BOOTSTRAP_DOMAIN' $KNIFE_HTTP_PROXY_PARAM -P vagrant --sudo $vm.$BOOTSTRAP_DOMAIN"
 done
 
 # augment the previously configured nodes with our newly uploaded environments and roles


### PR DESCRIPTION
This is for proxy environments where CA's are required for the given environment.

Specify 'ssl_ca_file_path:' and 'ssl_intermediate_file_path:' in environment_config.yaml, paths should be relative to repo root (for example 'certificates/{whatever you want to call it}.ca.pem').
