### PR TITLE
Allow ISO download ignores

### DIFF
--- a/bootstrap/common/bootstrap_prereqs.sh
+++ b/bootstrap/common/bootstrap_prereqs.sh
@@ -62,9 +62,7 @@ ftp_file() {
 # Obtain an RHEL 7.2 image to be used for PXE booting in production.
 if [[ ! -z $COBBLER_BOOTSTRAP_ISO ]]; then
   if [[ $COBBLER_DOWNLOAD_ISO -eq 1 ]]; then
-    set +e
     download_file cobbler/isos/$COBBLER_BOOTSTRAP_ISO $COBBLER_REMOTE_URL_ISO
-    set -e
   fi
 fi
 

--- a/bootstrap/vms/vagrant/vagrant_base.sh
+++ b/bootstrap/vms/vagrant/vagrant_base.sh
@@ -21,7 +21,7 @@
 # the default of erroring out on anything that comes up such as 'already installed' etc. If nothing is passed in
 # then the default is assumed.
 # Note: This setting is only valid until something downstream (another script) overrides it.
-ERR=$1
+ERR=${1:-''}
 
 export BOOTSTRAP_CHEF_ENV=${BOOTSTRAP_CHEF_ENV:-"vagrant"}
 

--- a/bootstrap/vms/vagrant/vagrant_bootstrap_chef_client.sh
+++ b/bootstrap/vms/vagrant/vagrant_bootstrap_chef_client.sh
@@ -28,6 +28,8 @@ source vagrant_base.sh
 # 3. vagrant_bootstrap_chef_client.sh
 # Then do the mon, osd, rgw etc.
 
-do_on_node $CEPH_CHEF_BOOTSTRAP "sudo cp /ceph-files/cobbler/isos/*.iso /tmp"
+if [[ $COBBLER_DOWNLOAD_ISO -eq 1 ]]; then
+  do_on_node $CEPH_CHEF_BOOTSTRAP "sudo cp /ceph-files/cobbler/isos/*.iso /tmp"
+fi
 
 do_on_node $CEPH_CHEF_BOOTSTRAP "sudo chef-client"

--- a/bootstrap/vms/vagrant/vagrant_clean.sh
+++ b/bootstrap/vms/vagrant/vagrant_clean.sh
@@ -18,6 +18,6 @@
 # Exit immediately if anything goes wrong, instead of making things worse.
 set -e
 
-cd $REPO_ROOT/bootstrap/vms/vagrant && vagrant destroy -f
+cd $REPO_ROOT/bootstrap/vms/vagrant && vagrant halt && vagrant destroy -f
 rm -f $REPO_ROOT/bootstrap/vms/chef-bcs
 rm -f $REPO_ROOT/bootstrap/vms/chef-bcs.pub


### PR DESCRIPTION
Addresses #49. If necessary proxy is mistakenly unset, the build should fail early due to `-e`. Also, some minor fixes including one regarding `vagrant_clean.sh`. Wrt the ISO downloads, it should now be sufficient to set `COBBLER_DOWNLOAD_ISO=0` in `base_environment.sh` to avoid the download altogether.
