### PR TITLE
Baseline install of Zabbix monitoring agent

### DIFF
--- a/bootstrap/common/bootstrap_prereqs.sh
+++ b/bootstrap/common/bootstrap_prereqs.sh
@@ -146,9 +146,6 @@ done
 
 # TODO: Need to clean up what is not needed below!
 
-# Zabbix Agent
-download_file zabbix-agent-2.4.7-1.el7.x86_64.rpm http://repo.zabbix.com/zabbix/2.4/rhel/7/x86_64/
-
 # IF you just want all of the latest rpms
 
 # wget -r -l1 -np http://download.ceph.com/rpm-hammer/el7/x86_64/ -P . -A "*0.94.6*"

--- a/cookbooks/chef-bcs/recipes/zabbix-agent.rb
+++ b/cookbooks/chef-bcs/recipes/zabbix-agent.rb
@@ -1,0 +1,45 @@
+#
+# Cookbook Name:: chef-bcs
+#
+# Copyright 2016, Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+yum_repository 'zabbix' do
+  baseurl node['chef-bcs']['zabbix']['repository']
+  gpgkey node['chef-bcs']['zabbix']['repository_key']
+end
+
+%w{zabbix-agent zabbix-sender}.each do |pkg|
+  package "#{pkg}" do
+    action :install
+  end
+end
+
+template '/etc/zabbix/zabbix_agentd.conf' do
+  source 'zabbix-zabbix_agentd.conf.erb'
+  owner 'root'
+  group 'root'
+  mode 00600
+  variables(
+    :zabbix_server => node['chef-bcs']['zabbix']['server'],
+    :agent_ip      => get_bond_ip
+  )
+  notifies :restart, 'service[zabbix-agent]', :delayed
+end
+
+service 'zabbix-agent' do
+  provider Chef::Provider::Service::Systemd
+  action [:enable, :start]
+end

--- a/cookbooks/chef-bcs/templates/default/zabbix-zabbix_agentd.conf.erb
+++ b/cookbooks/chef-bcs/templates/default/zabbix-zabbix_agentd.conf.erb
@@ -1,0 +1,15 @@
+################################################
+# Auto generated
+################################################
+PidFile=/var/run/zabbix/zabbix_agentd.pid
+LogFile=/var/log/zabbix/zabbix_agentd.log
+SourceIP=<%= @agent_ip %>
+EnableRemoteCommands=1
+LogRemoteCommands=1
+Server=<%= @zabbix_server %>
+ServerActive=<%= @zabbix_server %>
+ListenIP=<%= @agent_ip %>
+StartAgents=3
+Timeout=10
+Include=/etc/zabbix/zabbix_agentd.d/
+UnsafeUserParameters=1

--- a/environments/vagrant.json
+++ b/environments/vagrant.json
@@ -488,6 +488,11 @@
             "prefix": "collectd."
           }
         }
+      },
+      "zabbix": {
+        "repository": "http://repo.zabbix.com/zabbix/2.4/rhel/7/x86_64/",
+        "repository_key": "http://repo.zabbix.com/RPM-GPG-KEY-ZABBIX",
+        "server": "10.0.100.6"
       }
     },
     "chef_client": {

--- a/roles/monitoring.json
+++ b/roles/monitoring.json
@@ -3,6 +3,7 @@
   "json_class": "Chef::Role",
   "description": "Monitoring for Chef-BCS",
   "run_list": [
-    "recipe[chef-bcs::collectd]"
+    "recipe[chef-bcs::collectd]",
+    "recipe[chef-bcs::zabbix-agent]"
   ]
 }


### PR DESCRIPTION
If you do not already have a Zabbix server, there isn't a straight-forward way to perform integration testing. You have to either stand up a Zabbix server manually or run `zabbix_get -s 10.121.1.3 -I 10.0.100.6 -k system.uname` from `bcpc-vm4` created by [chef-bcpc](https://github.com/bloomberg/chef-bcpc).
