### PR TITLE
Renumber Vagrant nodes public IP addresses

### DIFF
--- a/bootstrap/vms/environment_config.yaml
+++ b/bootstrap/vms/environment_config.yaml
@@ -16,7 +16,7 @@ vagrant:
     dns:
       - 8.8.8.8
       - 8.8.4.4
-    front_end_adapter_ip: 10.121.1.1
+    front_end_adapter_ip: 10.0.100.1
     back_end_adapter_ip: 10.121.2.1
     memory: 2560
     cpus: 2

--- a/bootstrap/vms/servers_config.yaml
+++ b/bootstrap/vms/servers_config.yaml
@@ -6,7 +6,7 @@
 - name: ceph-bootstrap
   roles:
     - bootstrap
-  front_end_ip: 10.121.1.2
+  front_end_ip: 10.0.100.20
   back_end_ip: 10.121.2.2
 - name: ceph-vm1
   roles:
@@ -15,7 +15,7 @@
     - rgw
     - admin
     - adc
-  front_end_ip: 10.121.1.3
+  front_end_ip: 10.0.100.21
   back_end_ip: 10.121.2.3
 - name: ceph-vm2
   roles:
@@ -24,12 +24,12 @@
     - rgw
     - admin
     - adc
-  front_end_ip: 10.121.1.4
+  front_end_ip: 10.0.100.22
   back_end_ip: 10.121.2.4
 - name: ceph-vm3
   roles:
     - mon
     - osd
     - adc
-  front_end_ip: 10.121.1.5
+  front_end_ip: 10.0.100.23
   back_end_ip: 10.121.2.5

--- a/environments/vagrant.json
+++ b/environments/vagrant.json
@@ -18,7 +18,7 @@
         "name": "ceph-bootstrap",
         "env": "/home/vagrant/chef-bcs/environments",
         "interfaces": [
-          {"name": "enp0s8", "ip": "10.121.1.2", "netmask": "255.255.255.0", "gateway": ""},
+          {"name": "enp0s8", "ip": "10.0.100.20", "netmask": "255.255.255.0", "gateway": ""},
           {"name": "enp0s9", "ip": "10.121.2.2", "netmask": "255.255.255.0", "gateway": ""}
         ]
       },
@@ -145,7 +145,7 @@
       "cobbler": {
         "web_user": "cobbler",
         "pxe_interface": "enp0s3",
-        "server": "10.121.1.2",
+        "server": "10.0.100.20",
         "kickstart": {
           "NOTE": "password vagrant is: $6$Salt$6AyUczFy6SgV8A2wKAKfA9drpzrUsTGPJ3QjcWBbgS97BxBO.C7ZcBFALRiRkKfi9x8MK2SHet38BCQWS9LsR/",
           "root": {
@@ -197,9 +197,9 @@
               "public": {
                 "interface": "enp0s3",
                 "mac": "08:00:27:E3:84:01",
-                "ip": "10.121.1.3",
+                "ip": "10.0.100.20",
                 "netmask": "255.255.255.0",
-                "gateway": "10.121.1.2",
+                "gateway": "10.0.100.2",
                 "mtu": 1500
               },
               "cluster": {
@@ -220,9 +220,9 @@
               "public": {
                 "interface": "enp0s3",
                 "mac": "08:00:27:E3:84:01",
-                "ip": "10.121.1.3",
+                "ip": "10.0.100.21",
                 "netmask": "255.255.255.0",
-                "gateway": "10.121.1.2",
+                "gateway": "10.0.100.2",
                 "mtu": 1500
               },
               "cluster": {
@@ -243,9 +243,9 @@
               "public": {
                 "interface": "enp0s3",
                 "mac": "08:00:27:EB:EC:61",
-                "ip": "10.121.1.4",
+                "ip": "10.0.100.22",
                 "netmask": "255.255.255.0",
-                "gateway": "10.121.1.2",
+                "gateway": "10.0.100.2",
                 "mtu": 1500
               },
               "cluster": {
@@ -266,9 +266,9 @@
               "public": {
                 "interface": "enp0s3",
                 "mac": "08:00:27:8B:9F:3F",
-                "ip": "10.121.1.5",
+                "ip": "10.0.100.23",
                 "netmask": "255.255.255.0",
-                "gateway": "10.121.1.2",
+                "gateway": "10.0.100.2",
                 "mtu": 1500
               },
               "cluster": {
@@ -286,10 +286,10 @@
           "shared_network": "bcs",
           "single": {
             "netmask": "255.255.255.0",
-            "gateway": "10.121.1.2"
+            "gateway": "10.0.100.2"
           },
           "subnets":[
-            {"subnet": "10.121.1.0", "tag": "rack1", "dhcp_range": ["10.121.1.10", "10.121.1.254"], "netmask": "255.255.255.0", "router": "10.121.1.2"}
+            {"subnet": "10.0.100.0", "tag": "rack1", "dhcp_range": ["10.0.100.20", "10.0.100.30"], "netmask": "255.255.255.0", "router": "10.0.100.2"}
           ]
          },
         "NOTE1": "NOTE: Each subnet represents a routable rack so dhcp will need to manage each subnet with the TOR using IP-helper for dhcp requests by nodes in the given rack.",
@@ -461,7 +461,7 @@
         "public": {
           "interface": "enp0s8",
           "cidr": [
-            "10.121.1.0/24"
+            "10.0.100.0/24"
           ],
           "mtu": 1500
         },
@@ -491,7 +491,7 @@
       }
     },
     "chef_client": {
-      "server_url": "http://10.121.1.2:4000",
+      "server_url": "http://10.0.100.20:4000",
       "cache_path": "/var/chef/cache",
       "backup_path": "/var/chef/backup",
       "validation_client_name": "chef-validator",


### PR DESCRIPTION
Renumber them so chef-bcs nodes can co-exist in the same virtual network as [chef-bcpc](https://github.com/bloomberg/chef-bcpc) nodes. This is particularly useful when testing monitoring of chef-bcs with chef-bcpc's Zabbix.
