### PR TITLE
Speed up default collectd restarts

### DIFF
--- a/environments/vagrant.json
+++ b/environments/vagrant.json
@@ -484,7 +484,7 @@
         "write_graphite": {
           "node": {
             "id": "graphite",
-            "host": "10.0.100.6",
+            "host": "127.0.0.1",
             "port": 2013,
             "prefix": "collectd."
           }


### PR DESCRIPTION
Non-existent `10.0.100.6` Carbon endpoint will cause `write_graphite` to timeout and retry a few times. This increases each collectd service restart by about 80-90 seconds. Since having [chef-bcpc](https://github.com/bloomberg/chef-bcpc) running in parallel locally is likely a rare case, make `127.0.0.1` the default Carbon endpoint.
