### PR TITLE
Monitor MD RAID

### DIFF
--- a/cookbooks/chef-bcs/files/default/zabbix_scripts/raid_status.sh
+++ b/cookbooks/chef-bcs/files/default/zabbix_scripts/raid_status.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Copyright 2016, Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+MDSTAT=/proc/mdstat
+
+# Check for existence of RAID array
+grep -q ^md $MDSTAT || { echo 'OK - No RAID configured' && exit 0; }
+
+# Check for existence of RAID degradation
+STATUS="`grep -A 1 ^md $MDSTAT | grep -B 1 '\[.*_.*\]'`"
+
+if [ $? -eq 0 ]; then
+  echo "$STATUS" | grep -o '^md.*:' | awk '{print $1}' | tr '\n' ' ' | \
+  sed 's/^/Fault found on RAID device(s): /'
+else
+  echo 'OK - RAID appears healthy'
+fi

--- a/cookbooks/chef-bcs/recipes/zabbix-agent.rb
+++ b/cookbooks/chef-bcs/recipes/zabbix-agent.rb
@@ -49,7 +49,7 @@ template '/etc/zabbix/zabbix_agentd.conf' do
   notifies :restart, 'service[zabbix-agent]', :delayed
 end
 
-%w{ ceph radosgw haproxy }.each do |component|
+%w{ ceph radosgw haproxy raid }.each do |component|
   template "/etc/zabbix/zabbix_agentd.d/userparameter_#{component}.conf" do
     source "zabbix-userparameter-#{component}.conf.erb"
     owner 'zabbix'
@@ -65,6 +65,13 @@ execute 'systemd-reload' do
 end
 
 directory '/etc/systemd/system/zabbix-agent.service.d' do
+  owner 'root'
+  group 'root'
+  mode 00755
+end
+
+cookbook_file '/usr/local/bin/raid_status.sh' do
+  source 'zabbix_scripts/raid_status.sh'
   owner 'root'
   group 'root'
   mode 00755

--- a/cookbooks/chef-bcs/templates/default/zabbix-userparameter-raid.conf.erb
+++ b/cookbooks/chef-bcs/templates/default/zabbix-userparameter-raid.conf.erb
@@ -1,0 +1,4 @@
+################################################
+# Auto generated
+################################################
+UserParameter=raid.status,HOME=/var/lib/zabbix /usr/local/bin/raid_status.sh


### PR DESCRIPTION
Configure a Zabbix agent item to monitor MD RAID.