### PR TITLE
Filter Ceph health warnings

### DIFF
--- a/cookbooks/chef-bcs/files/default/scripts/ceph_health_filter.sh
+++ b/cookbooks/chef-bcs/files/default/scripts/ceph_health_filter.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# This Zabbix agent script parses the output of `ceph health` and attempts to
+# distinguish between blocked/slow ops and other likely more serious events.
+# The use of parameterized thresholds allow you to ignore (some) blocked ops /
+# slow OSDs at your own risk. Pass "0" as thresholds if you do not ever want to
+# ignore blocked ops and slow OSDs.
+#
+# Usage:
+# ceph health | ceph_health_filter <blocked op threshold> <slow OSD threshold>
+
+BLOCKED_OP_RE='[0-9]+ (ops|requests)\ are\ blocked'
+BLOCKED_OP_MIN=$1
+SLOW_OSD_RE='[0-9]+ osds\ have\ slow\ request'
+SLOW_OSD_MIN=$2
+
+STDIN=$(cat)
+
+# Report Ceph health output verbatim if it is not HEALTH_WARN
+echo $STDIN | grep -q ^HEALTH_WARN >/dev/null 2>&1 \
+|| { echo "$STDIN" && exit 0; }
+
+# If HEALTH_WARN highlights any non-slow/blocked warnings, we exit and trigger
+# a regular HEALTH_WARN
+COMBINED_RE="($BLOCKED_OP_RE|$SLOW_OSD_RE)"
+if [ "`echo "$STDIN" | egrep -vc \"$COMBINED_RE\"`" -ge 1 ]; then
+  echo "$STDIN" | sed 's/^HEALTH_WARN/HEALTH_WARN_non_blocked/'
+  exit 0
+fi
+
+BLOCKED_OP_TXT="`echo \"$STDIN\" | egrep -m 1 -o \"$BLOCKED_OP_RE\"`"
+BLOCKED_OP="`echo "$BLOCKED_OP_TXT" | awk '{print $1}'`"
+
+SLOW_OSD_TXT="`echo \"$STDIN\" | egrep -m 1 -o \"$SLOW_OSD_RE\"`"
+SLOW_OSD="`echo "$SLOW_OSD_TXT" | awk '{print $1}'`"
+
+# If blocked ops/slow OSDs do not hit threshold, treat state as HEALTH_OK
+if [ $BLOCKED_OP -ge $BLOCKED_OP_MIN ] || [ $SLOW_OSD -ge $SLOW_OSD_MIN ]; then
+  echo "$STDIN" | sed 's/^HEALTH_WARN/HEALTH_WARN_blocked/'
+else
+  echo HEALTH_OK
+fi

--- a/cookbooks/chef-bcs/files/default/scripts/ceph_if_leader.sh
+++ b/cookbooks/chef-bcs/files/default/scripts/ceph_if_leader.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Helper to check if node is Ceph leader
+
+ceph quorum_status -f json-pretty | \
+grep quorum_leader_name | grep -q `hostname -s` >/dev/null
+
+if [ $? -eq 0 ]; then
+  $*
+fi

--- a/cookbooks/chef-bcs/recipes/ceph-scripts.rb
+++ b/cookbooks/chef-bcs/recipes/ceph-scripts.rb
@@ -23,3 +23,9 @@ template '/etc/ceph/scripts/restart_down_osds.sh' do
     source 'restart_down_osds.sh.erb'
     mode 00755
 end
+
+%W( if_leader health_filter ).each do |script|
+    link "/usr/local/bin/ceph_#{script}.sh" do
+        to "/etc/ceph/scripts/ceph_#{script}.sh"
+    end
+end

--- a/cookbooks/chef-bcs/templates/default/zabbix-userparameter-ceph.conf.erb
+++ b/cookbooks/chef-bcs/templates/default/zabbix-userparameter-ceph.conf.erb
@@ -1,10 +1,11 @@
 ################################################
 # Auto generated
 ################################################
-UserParameter=ceph.health,HOME=/var/lib/zabbix ceph health | head -1
+UserParameter=ceph.health[*],HOME=/var/lib/zabbix ceph health | ceph_health_filter.sh $1 $2 | head -1
 UserParameter=ceph.pg_count[*],HOME=/var/lib/zabbix ceph pg dump 2>/dev/null | egrep "^[0-9a-f]+\.[0-9a-f]*\w" | grep -c "$1"
 UserParameter=ceph.pool.usage[*],HOME=/var/lib/zabbix rados df | egrep "^$1 " | awk '{}{print $$3}'
 UserParameter=ceph.pool.objects[*],HOME=/var/lib/zabbix rados df | egrep "^$1 " | awk '{}{print $$4}'
 UserParameter=ceph.total.usage[*],HOME=/var/lib/zabbix rados df | egrep "total used" | awk '{}{print $$3}' | tr -d '\n'
 UserParameter=ceph.total.space[*],HOME=/var/lib/zabbix rados df | egrep "total space" | awk '{}{print $$3}' | tr -d '\n'
 UserParameter=ceph.total.objects[*],HOME=/var/lib/zabbix rados df | egrep "total used" | awk '{}{print $$4}' | tr -d '\n'
+UserParameter=ceph.leader,HOME=/var/lib/zabbix /usr/local/bin/ceph_if_leader echo leader | wc -l


### PR DESCRIPTION
Blocked ops could be a frequent cause of Ceph health warnings, so filter `ceph health` to help Zabbix distinguish the warning category. In addition, introduce helper script to identify Ceph leader to facilitate de-duplication of alerts on Zabbix server.

