### PR TITLE
Parameterize thresholds for Ceph health filter

### DIFF
--- a/cookbooks/chef-bcs/templates/default/zabbix-userparameter-ceph.conf.erb
+++ b/cookbooks/chef-bcs/templates/default/zabbix-userparameter-ceph.conf.erb
@@ -1,11 +1,11 @@
 ################################################
 # Auto generated
 ################################################
-UserParameter=ceph.health[*],HOME=/var/lib/zabbix ceph health | ceph_health_filter.sh $1 $2 | head -1
+UserParameter=ceph.health,HOME=/var/lib/zabbix ceph health | ceph_health_filter.sh <%= node['chef-bcs']['zabbix']['ceph']['blocked_op'] %> <%= node['chef-bcs']['zabbix']['ceph']['slow_osd'] %> | head -1
 UserParameter=ceph.pg_count[*],HOME=/var/lib/zabbix ceph pg dump 2>/dev/null | egrep "^[0-9a-f]+\.[0-9a-f]*\w" | grep -c "$1"
 UserParameter=ceph.pool.usage[*],HOME=/var/lib/zabbix rados df | egrep "^$1 " | awk '{}{print $$3}'
 UserParameter=ceph.pool.objects[*],HOME=/var/lib/zabbix rados df | egrep "^$1 " | awk '{}{print $$4}'
 UserParameter=ceph.total.usage[*],HOME=/var/lib/zabbix rados df | egrep "total used" | awk '{}{print $$3}' | tr -d '\n'
 UserParameter=ceph.total.space[*],HOME=/var/lib/zabbix rados df | egrep "total space" | awk '{}{print $$3}' | tr -d '\n'
 UserParameter=ceph.total.objects[*],HOME=/var/lib/zabbix rados df | egrep "total used" | awk '{}{print $$4}' | tr -d '\n'
-UserParameter=ceph.leader,HOME=/var/lib/zabbix /usr/local/bin/ceph_if_leader echo leader | wc -l
+UserParameter=ceph.leader,HOME=/var/lib/zabbix /usr/local/bin/ceph_if_leader.sh echo leader | wc -l

--- a/environments/vagrant.json
+++ b/environments/vagrant.json
@@ -689,7 +689,11 @@
       "zabbix": {
         "repository": "http://repo.zabbix.com/zabbix/2.4/rhel/7/x86_64/",
         "repository_key": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-ZABBIX",
-        "server": "10.0.100.6"
+        "server": "10.0.100.6",
+        "ceph": {
+         "blocked_op": 0,
+         "slow_osd": 0
+        }
       }
     },
     "chef_client": {


### PR DESCRIPTION
Apply parameters on the client side instead of leveraging Zabbix server to pass arguments. This also fixes the leader script name.